### PR TITLE
Diversos cambios

### DIFF
--- a/app/Filament/Resources/OrderResource.php
+++ b/app/Filament/Resources/OrderResource.php
@@ -14,6 +14,7 @@ use Filament\Support\Enums\Alignment;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Filament\Support\RawJs;
+use Filament\Forms\Components\TextInput;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 
@@ -77,7 +78,11 @@ class OrderResource extends Resource
                             ->mask(RawJs::make('$money($input)'))
                             ->stripCharacters(',')
                             ->extraInputAttributes(['style' => 'text-align: right;'])
-                            ->disabled(),
+                            ->disabled()
+                            ->dehydrated(false)
+                            ->afterStateHydrated(function (TextInput $component, $record) {
+                                $component->state($record->grand_total ?? 0);
+                            }),
                         Forms\Components\TextInput::make('currency')
                             ->label(__('Moneda'))
                             ->maxLength(255)
@@ -93,7 +98,11 @@ class OrderResource extends Resource
                             ->label(__('Cantidad Enviada'))
                             ->default(0)
                             ->extraInputAttributes(['style' => 'text-align: right;'])
-                            ->disabled(),
+                            ->disabled()
+                            ->dehydrated(false)
+                            ->afterStateHydrated(function (TextInput $component, $record) {
+                                $component->state($record->shipping_amount ?? 0);
+                            }),
                         Forms\Components\TextInput::make('shipping_method')
                             ->label(__('Método de envío'))
                             ->maxLength(255),
@@ -101,16 +110,17 @@ class OrderResource extends Resource
                     ->columns(6),
                 Forms\Components\Grid::make()
                     ->schema([
+                        Forms\Components\Textarea::make('notes')
+                            ->label(__('Notas'))
+                            ->columnSpanFull(),
                         Forms\Components\ToggleButtons::make('status')
                             ->label(__('Situación'))
                             ->inline()
                             ->required()
                             ->default(OrderStatus::Nuevo)
                             ->options(OrderStatus::class)
-                            ->columnSpanFull(),
-                        Forms\Components\Textarea::make('notes')
-                            ->label(__('Notas'))
-                            ->columnSpanFull(),
+                            ->columnSpanFull()
+                            ->hidden(fn ($record) => $record === null || !$record->address()->exists()),
                     ])->columns(1),
             ]);
     }

--- a/app/Filament/Resources/OrderResource/Pages/EditOrder.php
+++ b/app/Filament/Resources/OrderResource/Pages/EditOrder.php
@@ -16,4 +16,21 @@ class EditOrder extends EditRecord
             Actions\DeleteAction::make(),
         ];
     }
+
+    protected function getListeners(): array
+    {
+        return array_merge(
+            parent::getListeners(),
+            [
+                'pedidoActualizado' => 'refrescarPedido',
+            ]
+        );
+    }
+
+    public function refrescarPedido()
+    {
+        $this->record->recalculateTotal();
+        $this->record->refresh();
+        $this->fillForm();
+    }
 }

--- a/app/Filament/Resources/OrderResource/RelationManagers/AddressRelationManager.php
+++ b/app/Filament/Resources/OrderResource/RelationManagers/AddressRelationManager.php
@@ -10,6 +10,7 @@ use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Livewire\Component;
 
 class AddressRelationManager extends RelationManager
 {
@@ -71,37 +72,29 @@ class AddressRelationManager extends RelationManager
     {
         return $table
             ->recordTitleAttribute('id')
+            ->paginated(false)
             ->columns([
-            Tables\Columns\TextColumn::make('first_name')
-                ->label(__('Nombre'))
-                ->sortable()
-                ->searchable(),
-            Tables\Columns\TextColumn::make('last_name')
-                ->label(__('Apellidos'))
-                ->sortable()
-                ->searchable(),
+            Tables\Columns\TextColumn::make('nombre_completo')
+                ->label(__('Nombre y Apellidos')),
             Tables\Columns\TextColumn::make('phone')
-                ->label(__('Teléfono'))
-                ->searchable(),
+                ->label(__('Teléfono')),
             Tables\Columns\TextColumn::make('zip_code')
-                ->label(__('C.postal/Zip Code'))
-                ->searchable(),
+                ->label(__('C.postal/Zip Code')),
             Tables\Columns\TextColumn::make('city')
-                ->label(__('Localidad/Ciudad'))
-                ->searchable(),
+                ->label(__('Localidad/Ciudad')),
             Tables\Columns\TextColumn::make('state')
-                ->label(__('Provincia/Estado'))
-                ->searchable(),
-            ])
-            ->filters([
-                //
+                ->label(__('Provincia/Estado')),
             ])
             ->actions([
-                Tables\Actions\EditAction::make(),
-                Tables\Actions\DeleteAction::make(),
+                Tables\Actions\EditAction::make()
+                    ->modalHeading('Editar Dirección de envío del pedido'),
             ])
             ->emptyStateActions([
-                Tables\Actions\CreateAction::make(),
+                Tables\Actions\CreateAction::make()
+                    ->createAnother(false)
+                    ->after(function (Component $livewire) {
+                        $livewire->dispatch('pedidoActualizado');
+                    }),
             ])
             ->emptyStateDescription(__('No hay direcciones de envío actualmente'));
     }

--- a/app/Filament/Resources/OrderResource/RelationManagers/OrderItemsRelationManager.php
+++ b/app/Filament/Resources/OrderResource/RelationManagers/OrderItemsRelationManager.php
@@ -10,6 +10,7 @@ use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Support\Enums\Alignment;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Livewire\Component;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
@@ -95,12 +96,11 @@ class OrderItemsRelationManager extends RelationManager
         return $table
         ->recordTitleAttribute('id')
         ->columns([
-            Tables\Columns\TextColumn::make('id')
+            Tables\Columns\TextColumn::make('Linea')
                 ->label(__('Línea'))
-                ->sortable()
-                ->searchable()
                 ->prefix('#')
                 ->suffix('#')
+                ->rowindex()
                 ->alignment(Alignment::Center),
             Tables\Columns\TextColumn::make('product.name')
                 ->label(__('Producto'))
@@ -115,6 +115,7 @@ class OrderItemsRelationManager extends RelationManager
                 ->numeric(2)
                 ->label(__('Precio unitario'))
                 ->alignment(Alignment::Right)
+                ->sortable()
                 ->searchable(),
             Tables\Columns\TextColumn::make('total_amount')
                 ->numeric(2)
@@ -134,19 +135,37 @@ class OrderItemsRelationManager extends RelationManager
                 ->searchable(),
             ])
             ->headerActions([
-                Tables\Actions\CreateAction::make(),
+                Tables\Actions\CreateAction::make()
+                ->after(function (Component $livewire) {
+                    $livewire->dispatch('pedidoActualizado');
+                }),
             ])
             ->actions([
-                Tables\Actions\EditAction::make(),
-                Tables\Actions\DeleteAction::make(),
-            ])
+                Tables\Actions\EditAction::make()
+                    ->modalHeading('Editar Línea de pedido')
+                    ->after(function (Component $livewire) {
+                        $livewire->dispatch('pedidoActualizado');
+                    }),
+                Tables\Actions\DeleteAction::make()
+                    ->modalHeading('Borrar Línea de pedido')
+                    ->after(function (Component $livewire) {
+                        $livewire->dispatch('pedidoActualizado');
+                    }),
+                ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
-                    Tables\Actions\DeleteBulkAction::make(),
+                    Tables\Actions\DeleteBulkAction::make()
+                        ->modalHeading('Borrar Líneas de pedidos')
+                        ->after(function (Component $livewire) {
+                            $livewire->dispatch('pedidoActualizado');
+                        }),
                 ]),
             ])
             ->emptyStateActions([
-                Tables\Actions\CreateAction::make(),
+                Tables\Actions\CreateAction::make()
+                ->after(function (Component $livewire) {
+                    $livewire->dispatch('pedidoActualizado');
+                }),
             ])
             ->emptyStateDescription(__('No hay líneas de pedidos actualmente'));
     }

--- a/app/Models/Address.php
+++ b/app/Models/Address.php
@@ -21,4 +21,9 @@ class Address extends Model
     public function order():BelongsTo {
         return $this->belongsTo(Order::class);
     }
+
+    public function getNombreCompletoAttribute()
+    {
+        return $this->first_name . ' ' . $this->last_name;
+    }
 }

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -9,6 +9,7 @@ use Filament\Pages;
 use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\Support\Colors\Color;
+use Filament\Support\Enums\MaxWidth;
 use Filament\Widgets;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Cookie\Middleware\EncryptCookies;
@@ -28,6 +29,9 @@ class AdminPanelProvider extends PanelProvider
             ->path('admin')
             ->login()
             ->registration()
+            ->sidebarCollapsibleOnDesktop()
+            ->maxContentWidth(MaxWidth::Full)
+            ->sidebarWidth('12rem')
             ->colors([
                 'primary' => Color::Amber,
             ])

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,9 @@
     "requires": true,
     "packages": {
         "": {
+            "dependencies": {
+                "preline": "^2.6.0"
+            },
             "devDependencies": {
                 "autoprefixer": "^10.4.20",
                 "axios": "^1.7.4",
@@ -581,6 +584,16 @@
             "optional": true,
             "engines": {
                 "node": ">=14"
+            }
+        },
+        "node_modules/@popperjs/core": {
+            "version": "2.11.8",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/popperjs"
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1975,6 +1988,15 @@
             "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
             "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
             "dev": true
+        },
+        "node_modules/preline": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/preline/-/preline-2.6.0.tgz",
+            "integrity": "sha512-8O9ayfWgicM8w64k6HIXoRafVqI3xsyFhlT/OCR99USR5izlMGvCunAW+HsTtCwWI0V04m96eXcYy8ElYkDqNg==",
+            "license": "Licensed under MIT and Preline UI Fair Use License",
+            "dependencies": {
+                "@popperjs/core": "^2.11.2"
+            }
         },
         "node_modules/proxy-from-env": {
             "version": "1.1.0",


### PR DESCRIPTION
Cambiar el ancho de los paneles y colapsado del panel de navegación.
Sustituir, en la lista de líneas de pedido, el campo id por el número de línea.
Crear todo el entorno desarrollando eventos para el refresco del total y de la cantidad enviada,
Permitir o no modificar el estado del pedido si existe o no una dirección de envío.
Sólo se permite crear una dirección de envío. Una vez creada, sólo se deja modificar, nunca borrar.
Quitar la paginación de la lista de direcciones de envío, no tiene sentido tenerla porque sólo puede existir una dirección de envío.
En la lista de direcciones de envío, unir la presentación del nombre y de los apellidos.
Cambiar el título de las ventanas modales de introducción de líneas de pedido y de direcciones de envío para que sean más aclaratorias.
No se permite en la lista de direcciones ni buscar ni ordenar, no tiene ningún sentido, sólo puede existir una.